### PR TITLE
Two windows-based installation instruction updates

### DIFF
--- a/bash.md
+++ b/bash.md
@@ -34,9 +34,11 @@ Then run the installer and follow these steps:
 
 - Click on "Next".
 - Click on "Next".
+- Choose "Nano" as the editor (unless you know you prefer vi or notepad++)
 - Keep "Use Git from the Windows Command Prompt" selected and click on "Next".
   If you forgot to do this programs that you need for the workshop will not work properly.
   If this happens rerun the installer and select the appropriate option.
+- Click on "Next".
 - Click on "Next".
 - Keep "Checkout Windows-style, commit Unix-style line endings" selected and click on "Next".
 - Keep "Use Windows' default console window" selected and click on "Next".

--- a/make.md
+++ b/make.md
@@ -55,7 +55,7 @@ You will now be able to run make within your shell.
 
 Get make:
 
-- Go to [http://gnuwin32.sourceforge.net/install.html](http://gnuwin32.sourceforge.net/install.html) and click on "Package List" link in the Installation section.
+- Go to [http://gnuwin32.sourceforge.net/](http://gnuwin32.sourceforge.net/) and click on the "Packages" link in the left side bar under "Download".
 - Download and install make.
 
 Add make to your user path variable:


### PR DESCRIPTION
I don't use windows much, but I tested on an Aalto computer and found these two things to fix.

- I assume nano is preferable to vi.  If not, this should be changed back.
- mingw seems to fail with a download error.  Is it install able for others?