### PR TITLE
add list of required accounts, fixes #55

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,11 +21,25 @@ Please follow the instructions for your operating system.
 - [Terminal editors](/installation/editors/)
 - [Configuration problems and solutions](/installation/troubleshooting/)
 
+## Accounts
+
+A couple of accounts are needed during the course. The motivation
+for this is to provide a real life hands-on experience using tools with massive
+traction and network effect.  
+
+We recommend that all participants who do not yet have user accounts on the following 
+platforms create new accounts before the workshop starts:
+
+- [GitHub](https://github.com/)
+- [Travis CI](https://travis-ci.org/)
+- [Coveralls](https://coveralls.io/)
+- [Read the Docs](https://readthedocs.org/)
+
+These accounts can later be removed, if desired, according to the instructions given below.
+
 ## Instructions for removing accounts
 
-We create a couple of accounts and projects during the course. The motivation
-for this is to provide a real life hands-on experience using tools with massive
-traction and network effect.  However, you may wish to remove the projects and
+You may wish to remove the projects and
 accounts that we have created.  Here we list instructions for how to achieve
 that:
 


### PR DESCRIPTION
Makes sense i think to list required accounts to reduce the time it takes during workshop.
Included accounts: github, travis ci, coveralls, read the docs