### PR TITLE
JupyterLab extensions always need activation, even if using conda

### DIFF
--- a/jupyter.md
+++ b/jupyter.md
@@ -35,7 +35,8 @@ using `pip` and not `conda`, you will need to execute this command in a terminal
 activate widgets in Jupyter:
 
 ```shell
-$ jupyter nbextension enable --py widgetsnbextension
+ $ conda install nodejs
+ $ jupyter nbextension enable --py widgetsnbextension
 ```
 
 

--- a/jupyter.md
+++ b/jupyter.md
@@ -24,18 +24,20 @@ $ conda install nodejs
 
 ### Widget extension
 
-If you did not install Python through Anaconda, and if you installed Jupyter 
-using `pip` and not `conda`, you will need to execute this command in a terminal in order to 
+To use widgets in JupyterLab, you also need to run the following
+command (even if you installed through conda):
+```shell
+$ jupyter labextension install @jupyter-widgets/jupyterlab-manager
+```
+
+For classic notebooks, *if you did not install Python through Anaconda*, and if you installed Jupyter
+using `pip` and not `conda`, you will need to execute this command in a terminal in order to
 activate widgets in Jupyter:
 
 ```shell
 $ jupyter nbextension enable --py widgetsnbextension
 ```
 
-To use widgets in JupyterLab, you also need to run the following command:
-```shell
-$ jupyter labextension install @jupyter-widgets/jupyterlab-manager
-```
 
 ### Diffing/merging notebooks
 


### PR DESCRIPTION
I found that, even if installing ipywidgets through conda, I had to
run the setup commands to enable the extensions (unlike for notebook).
After thinking about it, it makes sense to me.

I also reordered it so that jupyterlab instructions are first (it also
makes it more clear that these need to always be done), and also since
we now teach with jupyterlab.

To enable the jupyterlab extensions, I had to `conda install nodejs`.
Is this also expected?

Does anyone know is the above is the expected behavior?  Please don't
merge this until someone confirms.