### PR TITLE
Add more direct warnings to configure and verify git

### DIFF
--- a/git.md
+++ b/git.md
@@ -9,7 +9,9 @@ layout: master
   <p>
     Just installing git is not enough: you have to configure it, too.
     See <a href="#configuring-git">below</a>,
-    otherwise you will start off behind!
+    otherwise you will start off behind!  Then, <a
+    href="#how-to-verify-the-installation">verify it</a> (trust us on
+    this).
   </p>
 </div>
 

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Tools we use in a typical CodeRefinery workshop:
 - [Bash](/installation/bash/)
 - [Terminal editors](/installation/editors/)
 - [Python](/installation/python/)
-- [Git](/installation/git/)
+- [Git](/installation/git/), including [configuration](/installation/git/#configuring-git) and [verification](/installation/git/#how-to-verify-the-installation)
 - [Visual diff tools](/installation/difftools/)
 - [Jupyter and JupyterLab](/installation/jupyter/)
 - [Snakemake](/installation/snakemake/)


### PR DESCRIPTION
- I don't think we can make this too obvious - or can we?  Does it
  de-emphasize the other verifications?
- Please review: these links will work, right?