### PR TITLE
--show-origin option not working for me, perhaps not needed?

### DIFF
--- a/git.md
+++ b/git.md
@@ -165,7 +165,7 @@ $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -m
 
 To see where this information is stored, use:
 ```shell
-$ git config --list --show-origin
+$ git config --list
 ```
 
 

--- a/git.md
+++ b/git.md
@@ -163,7 +163,7 @@ executable and optionally set some options. For example (adjust the path if need
 $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession -noPlugin"
 ```
 
-To see where this information is stored, use:
+To see where this information is stored (`--show-origin` works on git version 2.8.0 or greater only), use:
 ```shell
 $ git config --list
 ```

--- a/git.md
+++ b/git.md
@@ -165,7 +165,7 @@ $ git config --global core.editor "'C:/Program Files/Notepad++/notepad++.exe' -m
 
 To see where this information is stored (`--show-origin` works on git version 2.8.0 or greater only), use:
 ```shell
-$ git config --list
+$ git config --list --show-origin
 ```
 
 


### PR DESCRIPTION
This PR is more of an issue:

In `git version 2.6.2.windows.1`
`git config --list --show-origin` says
`error: unknown option 'show-origin'`

But just `git config --list` does its job.

If there is any special purpose of using `--show-origin`, and if this is supported only in newer versions of git, then I'd suggest adding instructions for **updating git**.