### PR TITLE
python: Link coderefinery/software conda/requirements files

### DIFF
--- a/python.md
+++ b/python.md
@@ -8,6 +8,12 @@ We strongly recommend using Python version 3.5 or higher for the exercises in th
 workshop. If you only have version 2.7 installed, the instructions below 
 describe how you can set up an isolated Python 3 environment.
 
+> (optional) Advanced: The [coderefinery software
+> repository](https://github.com/coderefinery/software) has Conda
+> environment.yml and requirements.txt files for most Python software.
+> Currently, this is only for learners who already know how these tools
+> work.
+
 
 ## Installation on Linux and macOS
 


### PR DESCRIPTION
- Labeled as only for advanced people.  The instructions could be
  changed to use them more, after they have been tested.
- Linking mainly so that they aren't forgotten.
- To review: will this be too confusing at this stage?