### PR TITLE
added clarification before activating coderefinery env; closes #164

### DIFF
--- a/content/conda-environment.md
+++ b/content/conda-environment.md
@@ -3,9 +3,9 @@
 # Creating a Conda environment for CodeRefinery workshops
 
 1. Open your terminal shell (e.g. Bash)
-2. If you have not, activate `conda` in Miniconda first using `conda activate` and if this does not
-   work, please first follow {ref}`setting-conda-path`.  You probably
-   need to restart your shell terminal.
+2. If you have not, activate `conda` in Miniconda first using `conda activate` or `source ~/miniconda3/bin/activate`. If neither 
+   works, please first follow {ref}`setting-conda-path`. You probably
+   need to restart your shell terminal. Then try `conda activate` or `source ~/miniconda3/bin/activate` again.
 3. Run the following command:
    ```
    conda env create -f https://raw.githubusercontent.com/coderefinery/software/main/environment.yml
@@ -18,7 +18,10 @@
 
 ## Activating the `coderefinery` environment
 
-In the workshop, we will ask you to activate this environment like this:
+In the workshop, we will ask you to activate this environment. 
+
+First, follow the steps 1 and 2 in {ref}`the above section <conda-environment>` (i.e. open your terminal shell and activate `conda`).
+Then run the following:
 ```shell
 source activate coderefinery
 ```

--- a/content/conda-environment.md
+++ b/content/conda-environment.md
@@ -23,8 +23,15 @@ In the workshop, we will ask you to activate this environment.
 First, follow the steps 1 and 2 in {ref}`the above section <conda-environment>` (i.e. open your terminal shell and activate `conda`).
 Then run the following:
 ```shell
+conda activate coderefinery
+```
+Or you can use
+
+```shell
 source activate coderefinery
 ```
+as well. Please note however that `conda activate` is preferred command since conda ver. 4.4
+*Reference: conda Release notes, 4.4.0 (2017-12-20), [New feature highlights, "conda activate"](https://docs.conda.io/projects/conda/en/latest/release-notes.html#id226)*
 
 If this does not work, the `coderefinery` part should be replaced with the whole path, for example:
 ```shell


### PR DESCRIPTION
Added instruction to activate `conda` first before activating `coderefinery` environment. In Mac OS X Catalina, when opening a new terminal shell, it was necessary to do this first even though .bash_profile has `export PATH="/Users/naoetatara/miniconda3/bin:$PATH"`. Once it is done, even after deactivating base, as long as the same window opens it is possible to start from "source activate coderefinery" or "conda activate coderefinery"