### PR TITLE
Install notes for Meld 3.20.3 on Win, fixes #187

### DIFF
--- a/content/difftools.md
+++ b/content/difftools.md
@@ -20,6 +20,12 @@ anything else.
   $ git config --global diff.tool meld
   $ git config --global mergetool.meld.path "C:\Program Files (x86)\Meld\Meld.exe"
   ```
+  For meld version 3.20.3, because of reasons discussed [here](https://gitlab.gnome.org/GNOME/meld/-/issues/559), you can have multiple "Could not create key" errors that you can get around by clicking 'Ignore'.
+  Then, to open Meld when doing `git difftool`:
+  ```shell
+  $ git config --global diff.tool meld
+  $ git config --global mergetool.meld.path "$LOCALAPPDATA\Meld\Meld.exe"
+  ```
   ````
 
   ````{tab} macOS


### PR DESCRIPTION
As discussed [here](https://gitlab.gnome.org/GNOME/meld/-/issues/559), Meld 3.20.3 switched to local installation as default. This changed the default install location and also led to some errors where the installer tries to write to the Registry but without elevated privileges. The developers indicate that they might revert to system-wide install in later versions which means that this version might be the only one to have this bug. NB. Future versions will have a (non-default) option to do user only installs that might be suggested in the instructions.