### PR TITLE
revive installation instructions for docker and make, fixes #196

### DIFF
--- a/content/docker.md
+++ b/content/docker.md
@@ -1,0 +1,52 @@
+# Docker
+
+Docker provides a way to run applications securely isolated in a container,
+packaged with all its dependencies and libraries.
+
+**Note: Installing Docker is optional.** We will give a brief introduction to
+containers and how they can be used to package all dependencies and libraries
+together. It is not mandatory to have docker installed to get an idea about the
+containers. On the other hand, if you have Docker installed, then you can try
+creating images and running containers together with the instructor.
+
+
+## Installation on Linux
+
+Please visit the [Install Docker Engine](https://docs.docker.com/engine/install/) guide
+and follow the instructions for your Linux distribution ("Installation per distro" on
+the left sidebar).
+
+
+## Installation on macOS
+
+On macOS you can install Docker Community Ediiton using **Docker for Mac**
+app. The Docker for Mac install package includes everything you need to run
+Docker on a Mac.
+
+Please visit the [download and install Docker for
+Mac](https://docs.docker.com/docker-for-mac/install/) and install Docker app
+via Stable Channel.
+
+
+## Installation on Windows
+
+On Windows you can install Docker Community Edition using **Docker for
+Windows** app. The Docker for Windows install package includes everything you
+need to run Docker on a Windows system.
+
+Please visit the [download and install Docker for
+Windows](https://docs.docker.com/docker-for-windows/install/) and install
+Docker app via Stable Channel.
+
+
+## How to verify the installation
+
+The following command should give you the docker version and not throw errors:
+
+```shell
+$ docker --version
+```
+
+## If you would like to publish/share docker images
+
+Create an account in [Docker Hub](https://hub.docker.com/)

--- a/content/index.rst
+++ b/content/index.rst
@@ -81,6 +81,13 @@ If you encounter any problems
   motivation
   removing-accounts
 
+.. toctree::
+  :maxdepth: 1
+  :caption: Optional
+
+  docker
+  make
+  
 
 .. toctree::
    :maxdepth: 1

--- a/content/make.md
+++ b/content/make.md
@@ -1,0 +1,74 @@
+# Make
+
+
+## Installation on Linux
+
+Make is a standard tool on Linux systems and should already be available.
+If not, install make using your default distribution package manager.
+For Debian/Ubuntu run:
+
+```shell
+$ sudo apt-get install build-essential
+```
+
+For Fedora:
+
+```shell
+$ sudo dnf install make
+```
+
+Please also [verify your installation](#how-to-verify-the-installation).
+
+
+## Installation on macOS
+
+For OS X, version 10.9 (Mavericks) or above, download the Command Line Tools by doing:
+
+```
+$ xcode-select --install
+```
+
+For more information, see the [OSX Daily blog](http://osxdaily.com/2014/02/12/install-command-line-tools-mac-os-x/).
+
+If you have an older OS X version and you do not already have access to make from within your shell, you will need to install XCode (which is free, but over a gigabyte to download).
+
+- Go to the Apple app store
+- Search for XCode
+- Click Free
+- Click Install App
+
+Once XCode has installed:
+
+- Click Applications
+- Click XCode
+- Select XCode→Preferences...
+- Click Downloads
+- Select Command Line Tools
+- Click Install
+
+You will now be able to run make within your shell.
+
+Please also [verify your installation](#how-to-verify-the-installation).
+
+
+## Installation on Windows
+
+Get make:
+
+- Go to [http://gnuwin32.sourceforge.net/](http://gnuwin32.sourceforge.net/) and click on the "Packages" link in the left side bar under "Download".
+- Download and install make.
+
+Add make to your user path variable:
+
+- In control panel, search for "env", click on "Edit environmental variables for your account". In box for user variables, click PATH, click Edit ..., and add <location-of-make.exe> (probably `C:\Program Files (x86)\GnuWin32\bin`) at the end of the variables value, separated from the previous entry by a semicolon.
+
+Restart the computer.
+
+
+## How to verify the installation
+
+This command should give you the version of the Make tool and not throw errors:
+
+```shell
+$ make --version
+```


### PR DESCRIPTION
docker instructions greatly shortened to only point to official instructions rather than replicating the steps found there.

both `make` and `docker` instructions put under Optional section 