### PR TITLE
content/conda-environment: Link to the conda page as a prerequisite

### DIFF
--- a/content/conda-environment.md
+++ b/content/conda-environment.md
@@ -2,6 +2,8 @@
 
 # Creating a Conda environment for CodeRefinery workshops
 
+Prerequisite: installing conda from the {doc}`conda` page.
+
 1. Open your terminal shell (e.g. Bash)
 2. If you have not, activate `conda` in Miniconda first using `conda activate` or `source ~/miniconda3/bin/activate`. If neither 
    works, please first follow {ref}`setting-conda-path`. You probably


### PR DESCRIPTION
- I might link straight to this page and the back-link is useful.
