### PR TITLE
Updates to the vscode track

### DIFF
--- a/content/editors.md
+++ b/content/editors.md
@@ -41,6 +41,16 @@ If you choose a different editor, make sure to browse its documentation
 on how to conntect it to Git.
 ```
 
+This command will configure git to start VSCode as its editor.  (This
+will happen automatically if you select the VSCode option when
+installing Git for Windows.)
+
+```console
+$ git config --global core.editor "code --wait"
+```
+
+
+
 
 ## Nano (terminal)
 

--- a/content/git-in-terminal.md
+++ b/content/git-in-terminal.md
@@ -32,12 +32,19 @@ Please follow the installation, configuration, and verification instructions bel
     1.  Click on "Next" four times (two times if you've previously
         installed Git).  You don't need to change anything
         in the Information, location, components, and start menu screens.
-    2.  **From the dropdown menu select "Use the Nano editor by default"
-        (NOTE: you will need to scroll <emph>up</emph> to find it) and
-        click on "Next".**  If are comfortable with another editor and know it is
-        installed, you can select it - but Nano is the safest if you
-        don't know what to choose.  This replaces the "selecting an
-        editor" step below.
+    2.  **From the dropdown menu select an editor**:
+	    - If you use VSCode: Select that from the list.  You must have
+          VSCode installed already.
+	    - If you don't know what else to do: "Use the Nano editor by default"
+          (NOTE: you will need to scroll <emph>up</emph> to find it) and
+          click on "Next".**
+	    - If are comfortable with another editor and know it is
+          installed, you can select it - but Nano is the safest if you
+          don't know what to choose.
+
+        After this, you don't have to do step 2 "selecting an editor"
+        step below (but that step lets you change your choice).
+
     3.  **On the page that says "Adjusting the name of the initial branch in new repositories", choose
         "Override the default branch name for new repositories" and choose `main`. This will ensure
         the highest level of compatibility for our lessons.**

--- a/content/index.md
+++ b/content/index.md
@@ -35,6 +35,7 @@ several options on how to participate (below).
   In this case we recommend two things:
   - {ref}`github`
   - [Visual Studio Code](https://code.visualstudio.com/download) (or if you prefer, other {ref}`editors`)
+  - {ref}`git-in-terminal`
 ```
 
 ```{grid-item-card} I want to use Git from a terminal, not from an editor

--- a/content/ssh.md
+++ b/content/ssh.md
@@ -39,6 +39,14 @@ communicate with web sites. It's less secure if only a
 password is used, so GitHub doesn't allow normal passwords anymore.
 With an extra tool, it becomes easy and secure, though.
 ````
+
+````{group-tab} VSCode
+**If you use VSCode**.
+
+If you use VSCode, authentication to Github happens automatically via
+if you use **HTTPS**.
+````
+
 `````
 
 You should remember your choce for the lessons.
@@ -104,6 +112,13 @@ configuration step compared to other operating systems (since Linux
 has more options like connecting remotely to it to do work).  SSH is
 so natural on Linux you may as well do that.
 ````
+
+````{group-tab} VSCode
+
+No further setup is needed.  VSCode prompts you to automatically
+handles the authentication when needed.
+````
+
 `````
 
 
@@ -203,6 +218,8 @@ browwser, you might get this prompt:
 Select option 1 and do what it says.
 ````
 
-
+`````
+`````{group-tab} VSCode
+No further checking is needed (we hope).
 `````
 ``````

--- a/content/vscode.md
+++ b/content/vscode.md
@@ -24,3 +24,14 @@ for languages such as C++, Fortran, R, C#, Matlab, Java, Python, PHP, and Go.
 When installing Visual Studio Code, I have selected the options
 "Built-in terminal" and "Track your code with Git".
 ```
+
+## Using vscode as a git editor
+
+This will set VScode as the editor that Git starts.  It will start a
+new tab, and Git will wait until you save and close that tab.  Git for
+Windows on Windows may automatically set this if you select it as an
+editor:
+
+```console
+$ git config --global core.editor "code --wait"
+```


### PR DESCRIPTION
- git for windows is still needed (presumably the same for other
  operating systems, but it's there automatically)

- Notes about how to do set the editor, for the cases it's needed (I
  don't think it's automatically done by vscode?)

- Add VSCode to the SSH/HTTPS page that basically says "nothing is
  needed" - they shouldn't be looking here but this will clarify.
  (I'm not entirely sure how it works but people seem to find it
  does...)

- In Git for Windows instructions, further clarifications about the
  setting the editor: emphasize setting VSCode here.

- I think this probably works but is worth someone else taking a look
